### PR TITLE
bump lal to version 6.19.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "lalsuite" %}
-{% set version = "6.49" %}
+{% set version = "6.50" %}
 
 # sub-package versions
-{% set lal_version = "6.19.0" %}
+{% set lal_version = "6.19.1" %}
 {% set lalframe_version = "1.4.0" %}
 {% set lalmetaio_version = "1.4.0" %}
 {% set lalsimulation_version = "1.8.0" %}


### PR DESCRIPTION
This bumps the pinned lal version to 6.19.1 and bumps the lalsuite version accordingly.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
